### PR TITLE
Memory inflation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Box Specifications
     bwc.vm.provider :virtualbox do |vb|
       vb.name = "#{hostname}"
-      vb.memory = 2048
+      vb.memory = 3072
       vb.cpus = 2
     end
 


### PR DESCRIPTION
Inflation might be tamed in the fiscal world, but not in the world of developer memory requirements. Network Essentials install will fail with only 2GB of RAM.