### PR TITLE
Added memory for Suites Install

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # Box Specifications
     bwc.vm.provider :virtualbox do |vb|
       vb.name = "#{hostname}"
-      vb.memory = 3072
+      vb.memory = 4096
       vb.cpus = 2
     end
 


### PR DESCRIPTION
`vagrant up` will fail at installing network essentials step if system only has 3GB. Used to be OK, but no more. 
4GB seems to be OK.